### PR TITLE
feat: implement leaderboard functionality

### DIFF
--- a/ApplesGame/Constants.h
+++ b/ApplesGame/Constants.h
@@ -20,4 +20,5 @@ namespace ApplesGame
 	const int NUM_MENU_ITEMS = 8;
 	const int LEADERBOARD_DISPLAY_SIZE = 5;
 	const float LEADERBOARD_WIDTH = 500.f;
+	const std::string PLAYER_NAME = "Player";
 }

--- a/ApplesGame/Constants.h
+++ b/ApplesGame/Constants.h
@@ -18,4 +18,5 @@ namespace ApplesGame
 	const int POINTS_FOR_APPLE = 100;
 	const float STONE_SIZE = 15.f;
 	const int NUM_MENU_ITEMS = 8;
+	const int LEADERBOARD_DISPLAY_SIZE = 5;
 }

--- a/ApplesGame/Constants.h
+++ b/ApplesGame/Constants.h
@@ -4,8 +4,8 @@
 namespace ApplesGame
 {
 	const std::string RESOURCES_PATH = "Resources/";
-	const int SCREEN_WIDTH = 800;
-	const int SCREEN_HEIGHT = 600;
+	const int SCREEN_WIDTH = 1000;
+	const int SCREEN_HEIGHT = 750;
 	const float INITIAL_SPEED = 100.f; // Pixel per second
 	const float ACCELERATION = 20.f; // Acceleration per apple eaten
 	const float PLAYER_SIZE = 20.f;
@@ -19,4 +19,5 @@ namespace ApplesGame
 	const float STONE_SIZE = 15.f;
 	const int NUM_MENU_ITEMS = 8;
 	const int LEADERBOARD_DISPLAY_SIZE = 5;
+	const float LEADERBOARD_WIDTH = 500.f;
 }

--- a/ApplesGame/Game.cpp
+++ b/ApplesGame/Game.cpp
@@ -27,7 +27,6 @@ namespace ApplesGame
 		case GameState::MainMenu:
 		{
 			SetMenuState(game.uI, MenuState::MainMenu);
-			LoadLeaderboard(game.uI, game);
 			break;
 		}
 		case GameState::GameLoop:
@@ -43,6 +42,7 @@ namespace ApplesGame
 		{
 			PlaySound(game, game.deathSound);
 			SetMenuState(game.uI, MenuState::GameOverMenu);
+			SortLeaderboard(game.leaderboard);
 			LoadLeaderboard(game.uI, game);
 			break;
 		}
@@ -168,11 +168,12 @@ namespace ApplesGame
 
 		// Init leaderboard
 		game.leaderboard.clear();
-		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "John", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,10000) });
+		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,10000) });
+		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,10000) });
+		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,10000) });
+		game.leaderboard.push_back({ "John", GetRandomInt(1000,10000) });
+		SortLeaderboard(game.leaderboard);
 
 		game.apples = nullptr;
 		game.stones = nullptr;

--- a/ApplesGame/Game.cpp
+++ b/ApplesGame/Game.cpp
@@ -174,7 +174,7 @@ namespace ApplesGame
 
 	void StartGameLoop(Game& game)
 	{
-		game.score = 0;
+		game.playerScore = 0;
 		InitPlayer(game.player, game);
 
 		FreeAppleMemoryAllocation(game);
@@ -207,11 +207,11 @@ namespace ApplesGame
 					
 					if (IsAppleSpecial(*ptrApple))
 					{
-						game.score += (unsigned int)(2.f * (float)POINTS_FOR_APPLE * GetScoreMultiplier(game.gameMode));
+						game.playerScore += (unsigned int)(2.f * (float)POINTS_FOR_APPLE * GetScoreMultiplier(game.gameMode));
 					}
 					else
 					{
-						game.score += (unsigned int)((float)POINTS_FOR_APPLE * GetScoreMultiplier(game.gameMode));
+						game.playerScore += (unsigned int)((float)POINTS_FOR_APPLE * GetScoreMultiplier(game.gameMode));
 					}
 
 					if (IsGameModeFlagOn(game.gameMode, GameModeFlag::AcceleratePlayer) && !(IsAppleSpecial(*ptrApple)))

--- a/ApplesGame/Game.cpp
+++ b/ApplesGame/Game.cpp
@@ -27,6 +27,7 @@ namespace ApplesGame
 		case GameState::MainMenu:
 		{
 			SetMenuState(game.uI, MenuState::MainMenu);
+			LoadLeaderboard(game.uI, game);
 			break;
 		}
 		case GameState::GameLoop:
@@ -42,6 +43,7 @@ namespace ApplesGame
 		{
 			PlaySound(game, game.deathSound);
 			SetMenuState(game.uI, MenuState::GameOverMenu);
+			LoadLeaderboard(game.uI, game);
 			break;
 		}
 		case GameState::ExitGame:
@@ -163,6 +165,14 @@ namespace ApplesGame
 
 		// Load font 
 		assert(game.font.loadFromFile(RESOURCES_PATH + "\\Fonts/Roboto-Regular.ttf"));
+
+		// Init leaderboard
+		game.leaderboard.clear();
+		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "John", GetRandomInt(1000,5000) });
 
 		game.apples = nullptr;
 		game.stones = nullptr;
@@ -328,6 +338,11 @@ namespace ApplesGame
 		case MenuItemType::RandomizeGameMode:
 		{
 			RandomizeGameMode(game.gameMode);
+			break;
+		}
+		case MenuItemType::Leaderboard:
+		{
+			SetMenuState(game.uI, MenuState::LeaderboardMenu);
 			break;
 		}
 		}

--- a/ApplesGame/Game.cpp
+++ b/ApplesGame/Game.cpp
@@ -42,6 +42,7 @@ namespace ApplesGame
 		{
 			PlaySound(game, game.deathSound);
 			SetMenuState(game.uI, MenuState::GameOverMenu);
+			UpdatePlayerScore(game);
 			SortLeaderboard(game.leaderboard);
 			LoadLeaderboard(game.uI, game);
 			break;
@@ -100,7 +101,7 @@ namespace ApplesGame
 		{
 		case GameState::MainMenu:
 		{
-			UpdateMenu(game.uI, game);
+			UpdateMenu(game.uI, game, deltaTime);
 			break;
 		}
 		case GameState::GameLoop:
@@ -111,12 +112,12 @@ namespace ApplesGame
 		}
 		case GameState::Pause:
 		{
-			UpdateMenu(game.uI, game);
+			UpdateMenu(game.uI, game, deltaTime);
 			break;
 		}
 		case GameState::GameOver:
 		{
-			UpdateMenu(game.uI, game);
+			UpdateMenu(game.uI, game, deltaTime);
 			break;
 		}
 		}
@@ -168,11 +169,11 @@ namespace ApplesGame
 
 		// Init leaderboard
 		game.leaderboard.clear();
-		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,10000) });
-		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,10000) });
-		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,10000) });
-		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,10000) });
-		game.leaderboard.push_back({ "John", GetRandomInt(1000,10000) });
+		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,5000) });
+		game.leaderboard.push_back({ "John", GetRandomInt(1000,5000) });
 		SortLeaderboard(game.leaderboard);
 
 		game.apples = nullptr;
@@ -408,5 +409,27 @@ namespace ApplesGame
 		FreeAppleMemoryAllocation(game);
 		FreeStoneMemoryAllocation(game);
 		window.close();
+	}
+
+	void UpdatePlayerScore(Game& game)
+	{
+		bool isPlayerFound = false;
+		for (Record& entry : game.leaderboard)
+		{
+			if (entry.name == PLAYER_NAME)
+			{
+				isPlayerFound = true;
+				if (game.playerScore > entry.score)
+				{
+					entry.score = game.playerScore;
+					game.uI.showNewRecordText = true;
+				}
+				break;
+			}
+		}
+		if (!isPlayerFound) {
+			game.leaderboard.push_back({ PLAYER_NAME, game.playerScore });
+			game.uI.showNewRecordText = true;
+		}
 	}
 }

--- a/ApplesGame/Game.h
+++ b/ApplesGame/Game.h
@@ -25,7 +25,8 @@ namespace ApplesGame
 		// Global game data
 		GameState gameState{};
 		uint32_t gameMode = 0;
-		unsigned int score = 0;
+		int playerScore = 0;
+		std::vector<Record> leaderboard;
 
 		//Resources
 		sf::Texture playerTexture;

--- a/ApplesGame/Game.h
+++ b/ApplesGame/Game.h
@@ -74,4 +74,6 @@ namespace ApplesGame
 	void FreeStoneMemoryAllocation(Game& game);
 
 	void DeinitializeGame(Game& game, sf::RenderWindow& window);
+
+	void UpdatePlayerScore(Game& game);
 }

--- a/ApplesGame/GameMode.cpp
+++ b/ApplesGame/GameMode.cpp
@@ -27,14 +27,24 @@ namespace ApplesGame
 		SetGameModeNum(gameMode, NumberOfStones, 16);
 	}
 
+	void InitLeaderboard(std::vector<Record>& leaderboard)
+	{
+		leaderboard.clear();
+		leaderboard.push_back({ "Alice", GetRandomInt(1000,10000)});
+		leaderboard.push_back({ "Bob", GetRandomInt(1000,10000) });
+		leaderboard.push_back({ "Carol", GetRandomInt(1000,10000) });
+		leaderboard.push_back({ "Dave", GetRandomInt(1000,10000) });
+		leaderboard.push_back({ "John", GetRandomInt(1000,10000) });
+	}
+
 	void RandomizeGameMode(uint32_t& gameMode)
 	{
-		SetGameModeNum(gameMode, NumberOfApples, (rand() % NumberOfApples.max_value + NumberOfApples.min_value));
-		SetGameModeNum(gameMode, NumberOfStones, (rand() % NumberOfStones.max_value + NumberOfStones.min_value));
-		SetGameModeFlag(gameMode, GameModeFlag::InfiniteApples, (rand() % 2));
-		SetGameModeFlag(gameMode, GameModeFlag::AcceleratePlayer, (rand() % 2));
-		SetGameModeFlag(gameMode, GameModeFlag::CollideWithBorders, (rand() % 2));
-		SetGameModeFlag(gameMode, GameModeFlag::SpawnSpecialApples, (rand() % 2));
+		SetGameModeNum(gameMode, NumberOfApples, GetRandomInt(NumberOfApples.min_value, NumberOfApples.max_value));
+		SetGameModeNum(gameMode, NumberOfStones, GetRandomInt(NumberOfStones.min_value, NumberOfStones.max_value));
+		SetGameModeFlag(gameMode, GameModeFlag::InfiniteApples, GetRandomInt(0, 1));
+		SetGameModeFlag(gameMode, GameModeFlag::AcceleratePlayer, GetRandomInt(0, 1));
+		SetGameModeFlag(gameMode, GameModeFlag::CollideWithBorders, GetRandomInt(0, 1));
+		SetGameModeFlag(gameMode, GameModeFlag::SpawnSpecialApples, GetRandomInt(0, 1));
 
 		if (!isGameModeConsistent(gameMode))
 		{

--- a/ApplesGame/GameMode.cpp
+++ b/ApplesGame/GameMode.cpp
@@ -27,16 +27,6 @@ namespace ApplesGame
 		SetGameModeNum(gameMode, NumberOfStones, 16);
 	}
 
-	void InitLeaderboard(std::vector<Record>& leaderboard)
-	{
-		leaderboard.clear();
-		leaderboard.push_back({ "Alice", GetRandomInt(1000,10000)});
-		leaderboard.push_back({ "Bob", GetRandomInt(1000,10000) });
-		leaderboard.push_back({ "Carol", GetRandomInt(1000,10000) });
-		leaderboard.push_back({ "Dave", GetRandomInt(1000,10000) });
-		leaderboard.push_back({ "John", GetRandomInt(1000,10000) });
-	}
-
 	void RandomizeGameMode(uint32_t& gameMode)
 	{
 		SetGameModeNum(gameMode, NumberOfApples, GetRandomInt(NumberOfApples.min_value, NumberOfApples.max_value));

--- a/ApplesGame/GameMode.cpp
+++ b/ApplesGame/GameMode.cpp
@@ -174,5 +174,18 @@ namespace ApplesGame
 		}
 		return true;
 	}
+
+	void SortLeaderboard(std::vector<Record>& leaderboard) 
+	{
+		for (unsigned int i = 1; i < leaderboard.size(); ++i) 
+		{
+			unsigned int j = i;
+			while (j > 0 && leaderboard[j - 1].score < leaderboard[j].score) 
+			{
+				std::swap(leaderboard[j - 1], leaderboard[j]);
+				--j;
+			}
+		}
+	}
 }
 

--- a/ApplesGame/GameMode.h
+++ b/ApplesGame/GameMode.h
@@ -50,4 +50,6 @@ namespace ApplesGame
 	float GetScoreMultiplier(uint32_t gameMode);
 
 	bool isGameModeConsistent(uint32_t gameMode);
+
+	void SortLeaderboard(std::vector<Record>& leaderboard);
 }

--- a/ApplesGame/GameMode.h
+++ b/ApplesGame/GameMode.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Math.h"
+#include <vector>
 
 namespace ApplesGame
 {
@@ -9,6 +10,12 @@ namespace ApplesGame
 		uint32_t mask;
 		uint8_t max_value;
 		uint8_t min_value;
+	};
+
+	struct Record
+	{
+		std::string name;
+		int score;
 	};
 
 	extern const GameModeNum NumberOfApples;
@@ -23,6 +30,8 @@ namespace ApplesGame
 	};
 
 	void InitGameMode(uint32_t& gameMode);
+
+	void InitLeaderboard(std::vector<Record>& leaderboard);
 
 	void RandomizeGameMode(uint32_t& gameMode);
 

--- a/ApplesGame/GameMode.h
+++ b/ApplesGame/GameMode.h
@@ -31,8 +31,6 @@ namespace ApplesGame
 
 	void InitGameMode(uint32_t& gameMode);
 
-	void InitLeaderboard(std::vector<Record>& leaderboard);
-
 	void RandomizeGameMode(uint32_t& gameMode);
 
 	void SwitchGameModeFlag(uint32_t& gameMode, const GameModeFlag& gameModeFlag);

--- a/ApplesGame/Math.cpp
+++ b/ApplesGame/Math.cpp
@@ -5,11 +5,21 @@
 
 namespace ApplesGame
 {
+	float GetRandomFloat(float minValue, float maxValue)
+	{
+		return minValue + (rand() / (float)RAND_MAX) * (maxValue - minValue);
+	}
+
+	int GetRandomInt(int minValue, int maxValue)
+	{
+		return minValue + rand() % (maxValue - minValue + 1);
+	}
+
 	Position2D GetRandomPositionInScreen(float screenWidth, float screenHeight)
 	{
 		Position2D result;
-		result.x = rand() / (float)RAND_MAX * screenWidth;
-		result.y = rand() / (float)RAND_MAX * screenHeight;
+		result.x = GetRandomFloat(0, screenWidth);
+		result.y = GetRandomFloat(0, screenHeight);
 		return result;
 	}
 
@@ -83,7 +93,7 @@ namespace ApplesGame
 
 	bool rollChance(float percent)
 	{
-		return (rand() / (float)RAND_MAX) < (percent / 100.f);
+		return GetRandomFloat(0, 100) <= percent;
 	}
 
 	std::string BoolToString(const bool& flag)

--- a/ApplesGame/Math.h
+++ b/ApplesGame/Math.h
@@ -23,6 +23,10 @@ namespace ApplesGame
 
 	typedef Vector2D Position2D;
 
+	float GetRandomFloat(float minValue, float maxValue);
+
+	int GetRandomInt(int minValue, int maxValue);
+
 	Position2D GetRandomPositionInScreen(float screenWidth, float screenHeight);
 
 	bool IsRectanglesCollide(Position2D rect1Position, Vector2D rect1Size, Position2D rect2Position, Vector2D rect2Size);

--- a/ApplesGame/Menu.h
+++ b/ApplesGame/Menu.h
@@ -17,7 +17,8 @@ namespace ApplesGame
 		CollideWithBorders,
 		SpawnSpecialApples,
 		NumberOfApples,
-		NumberOfStones
+		NumberOfStones,
+		Leaderboard
 	};
 
 	enum class MenuState
@@ -25,7 +26,8 @@ namespace ApplesGame
 		MainMenu = 0,
 		GameModeMenu,
 		PauseMenu,
-		GameOverMenu
+		GameOverMenu,
+		LeaderboardMenu
 	};
 
 	struct MenuItem

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -59,6 +59,14 @@ namespace ApplesGame
 			ShiftTextPozition(uI.leaderboardItems[i], 0.f, 42.f * i);
 		}
 		LoadLeaderboard(uI, game);
+
+		// Init New Record text
+		uI.newRecord.setString("New personal record!!!");
+		uI.newRecord.setFont(game.font);
+		uI.newRecord.setCharacterSize(35);
+		uI.newRecord.setFillColor(sf::Color::Yellow);
+		SetTextRelativeOrigin(uI.newRecord, 0.5f, 0.5f);
+		SetTextScreenRelativePosition(uI.newRecord, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.30f);
 	}
 
 	void UpdateHUD(UI& uI, const Game& game)
@@ -71,7 +79,7 @@ namespace ApplesGame
 		window.draw(uI.playerScore);
 	}
 
-	void UpdateMenu(UI& uI, const Game& game)
+	void UpdateMenu(UI& uI, const Game& game, const float deltaTime)
 	{
 		for (int i = 0; i < NUM_MENU_ITEMS; i++)
 		{
@@ -106,6 +114,10 @@ namespace ApplesGame
 		}
 		case MenuState::GameOverMenu:
 		{
+			if (uI.showNewRecordText)
+			{
+				UpdateBlinkText(uI.newRecord, 0.3f, deltaTime);
+			}
 			UpdateTextAndPosition(uI.note, "Final score: " + std::to_string(game.playerScore));
 			break;
 		}
@@ -200,6 +212,10 @@ namespace ApplesGame
 				window.draw(uI.leaderboardItems[i]);
 			}
 		}
+		if (uI.showNewRecordText)
+		{
+			window.draw(uI.newRecord);
+		}
 	}
 
 	void UpdateTextAndPosition(sf::Text& text, const std::string string)
@@ -213,6 +229,7 @@ namespace ApplesGame
 
 	void SetMenuState(UI& uI, const MenuState& menuState)
 	{
+		uI.showNewRecordText = false;
 		uI.menuState = menuState;
 		uI.menuSelectedItem = 0;
 		LoadNewMenu(uI);
@@ -264,6 +281,23 @@ namespace ApplesGame
 
 			SetTextRelativeOrigin(uI.leaderboardItems[i], relativeOrigin.x, relativeOrigin.y);
 			SetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT, relativePosition.x, relativePosition.y);
+		}
+	}
+
+	void UpdateBlinkText(sf::Text& text, const float blinkInterval, const float deltaTime) {
+		static float blinkAccumulator = 0.f;
+		static bool isRed = true;
+
+		blinkAccumulator += deltaTime;
+		if (blinkAccumulator >= blinkInterval) {
+			blinkAccumulator -= blinkInterval;
+			if (isRed) {
+				text.setFillColor(sf::Color::Yellow);
+			}
+			else {
+				text.setFillColor(sf::Color::Red);
+			}
+			isRed = !isRed;
 		}
 	}
 }

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -58,6 +58,7 @@ namespace ApplesGame
 			SetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.4f);
 			ShiftTextPozition(uI.leaderboardItems[i], 0.f, 42.f * i);
 		}
+		LoadLeaderboard(uI, game);
 	}
 
 	void UpdateHUD(UI& uI, const Game& game)
@@ -105,7 +106,7 @@ namespace ApplesGame
 		}
 		case MenuState::GameOverMenu:
 		{
-			UpdateTextAndPosition(uI.note, "Leaderboard");
+			UpdateTextAndPosition(uI.note, "Final score: " + std::to_string(game.playerScore));
 			break;
 		}
 		case MenuState::LeaderboardMenu:

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -266,7 +266,13 @@ namespace ApplesGame
 
 	void LoadLeaderboard(UI& uI, const Game& game)
 	{
-		for (int i = 0; i < LEADERBOARD_DISPLAY_SIZE; i++)
+		int displayCount = LEADERBOARD_DISPLAY_SIZE;
+		if (game.leaderboard.size() < LEADERBOARD_DISPLAY_SIZE)
+		{
+			displayCount = game.leaderboard.size();
+		}
+
+		for (int i = 0; i < displayCount; i++)
 		{
 			Vector2D relativePosition = GetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT);
 			Vector2D relativeOrigin = GetTextRelativeOrigin(uI.leaderboardItems[i]);

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -14,15 +14,15 @@ namespace ApplesGame
 		uI.title.setCharacterSize(100);
 		uI.title.setFillColor(sf::Color::Yellow);
 		SetTextRelativeOrigin(uI.title, 0.5f, 0.5f);
-		SetTextScreenRelativePosition(uI.title, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.15f);
+		SetTextScreenRelativePosition(uI.title, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.1f);
 
 		// Init Note
 		uI.note.setString("note");
 		uI.note.setFont(game.font);
-		uI.note.setCharacterSize(25);
+		uI.note.setCharacterSize(30);
 		uI.note.setFillColor(sf::Color::Yellow);
 		SetTextRelativeOrigin(uI.note, 0.5f, 0.5f);
-		SetTextScreenRelativePosition(uI.note, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.3f);
+		SetTextScreenRelativePosition(uI.note, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.25f);
 
 		// Init Menu Items
 		for (int i = 0; i < NUM_MENU_ITEMS; i++)
@@ -32,11 +32,9 @@ namespace ApplesGame
 			uI.menuItems[i].text.setCharacterSize(32);
 			uI.menuItems[i].text.setFillColor(sf::Color::Yellow);
 			SetTextRelativeOrigin(uI.menuItems[i].text, 0.5f, 0.5f);
-			SetTextScreenRelativePosition(uI.menuItems[i].text, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.4f);
-			ShiftTextPozition(uI.menuItems[i].text, 0.f, 42.f * i);
 		}
 
-		// Init Score
+		// Init Player Score
 		uI.playerScore.setString("score");
 		uI.playerScore.setFont(game.font);
 		uI.playerScore.setCharacterSize(20);
@@ -47,6 +45,19 @@ namespace ApplesGame
 		//Init tint
 		uI.tint.setFillColor(sf::Color(0, 0, 0, 180));
 		uI.tint.setSize(sf::Vector2f(SCREEN_WIDTH, SCREEN_HEIGHT));
+
+		//Init Leaderboard
+		uI.showLeaderboard = false;
+		for (int i = 0; i < LEADERBOARD_DISPLAY_SIZE; i++)
+		{
+			uI.leaderboardItems[i].setString("score " + std::to_string(i));
+			uI.leaderboardItems[i].setFont(game.font);
+			uI.leaderboardItems[i].setCharacterSize(32);
+			uI.leaderboardItems[i].setFillColor(sf::Color::Yellow);
+			SetTextRelativeOrigin(uI.leaderboardItems[i], 0.5f, 0.5f);
+			SetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.4f);
+			ShiftTextPozition(uI.leaderboardItems[i], 0.f, 42.f * i);
+		}
 	}
 
 	void UpdateHUD(UI& uI, const Game& game)
@@ -94,7 +105,12 @@ namespace ApplesGame
 		}
 		case MenuState::GameOverMenu:
 		{
-			UpdateTextAndPosition(uI.note, "Final score: " + std::to_string(game.playerScore));
+			UpdateTextAndPosition(uI.note, "Leaderboard");
+			break;
+		}
+		case MenuState::LeaderboardMenu:
+		{
+			UpdateTextAndPosition(uI.note, "Set a new record!!!");
 			break;
 		}
 		}
@@ -106,19 +122,23 @@ namespace ApplesGame
 		{
 			uI.menuItems[i].isActive = false;
 		}
+		uI.showLeaderboard = false;
 		switch (uI.menuState)
 		{
 		case MenuState::MainMenu:
 		{
 			UpdateTextAndPosition(uI.title, "Apples Game!");
+			SetMenuItemsPosition(uI, .0f, .0f);
 			SetMenuItem(uI.menuItems[0], "Start game", MenuItemType::StartGame);
 			SetMenuItem(uI.menuItems[1], "Game mode", MenuItemType::GameMode);
-			SetMenuItem(uI.menuItems[2], "Exit game", MenuItemType::ExitGame);
+			SetMenuItem(uI.menuItems[2], "Leaderboard", MenuItemType::Leaderboard);
+			SetMenuItem(uI.menuItems[3], "Exit game", MenuItemType::ExitGame);
 			break;
 		}
 		case MenuState::GameModeMenu:
 		{
-			UpdateTextAndPosition(uI.title, "Game mode");;
+			UpdateTextAndPosition(uI.title, "Game mode");
+			SetMenuItemsPosition(uI, .0f, .0f);
 			SetMenuItem(uI.menuItems[0], "Randomize", MenuItemType::RandomizeGameMode);
 			SetMenuItem(uI.menuItems[1], "Infinite Apples", MenuItemType::InfiniteApples);
 			SetMenuItem(uI.menuItems[2], "Accelerate Player", MenuItemType::AcceleratePlayer);
@@ -132,6 +152,7 @@ namespace ApplesGame
 		case MenuState::PauseMenu:
 		{
 			UpdateTextAndPosition(uI.title, "Pause");
+			SetMenuItemsPosition(uI, .0f, .0f);
 			SetMenuItem(uI.menuItems[0], "Continue game", MenuItemType::ContinueGame);
 			SetMenuItem(uI.menuItems[1], "Restart game", MenuItemType::StartGame);
 			SetMenuItem(uI.menuItems[2], "Back to main menu", MenuItemType::BackMainMenu);
@@ -140,10 +161,20 @@ namespace ApplesGame
 		}
 		case MenuState::GameOverMenu:
 		{
+			uI.showLeaderboard = true;
+			SetMenuItemsPosition(uI, .0f, 300.0f);
 			UpdateTextAndPosition(uI.title, "GAME OVER");
 			SetMenuItem(uI.menuItems[0], "Restart game", MenuItemType::StartGame);
 			SetMenuItem(uI.menuItems[1], "Back to main menu", MenuItemType::BackMainMenu);
 			SetMenuItem(uI.menuItems[2], "Exit game", MenuItemType::ExitGame);
+			break;
+		}
+		case MenuState::LeaderboardMenu:
+		{
+			uI.showLeaderboard = true;
+			SetMenuItemsPosition(uI, .0f, 300.0f);
+			UpdateTextAndPosition(uI.title, "Leaderboard");
+			SetMenuItem(uI.menuItems[0], "Back", MenuItemType::BackMainMenu);
 			break;
 		}
 		}
@@ -159,6 +190,13 @@ namespace ApplesGame
 			if (uI.menuItems[i].isActive)
 			{
 				window.draw(uI.menuItems[i].text);
+			}
+		}
+		if (uI.showLeaderboard)
+		{
+			for (int i = 0; i < LEADERBOARD_DISPLAY_SIZE; i++)
+			{
+				window.draw(uI.leaderboardItems[i]);
 			}
 		}
 	}
@@ -197,6 +235,35 @@ namespace ApplesGame
 		do {
 			uI.menuSelectedItem = (uI.menuSelectedItem + 1) % NUM_MENU_ITEMS;
 		} while (!uI.menuItems[uI.menuSelectedItem].isActive);
+	}
+
+	void SetMenuItemsPosition(UI& uI, float shiftX, float shiftY)
+	{
+		for (int i = 0; i < NUM_MENU_ITEMS; i++)
+		{
+			SetTextScreenRelativePosition(uI.menuItems[i].text, SCREEN_WIDTH, SCREEN_HEIGHT, 0.5f, 0.4f);
+			ShiftTextPozition(uI.menuItems[i].text, shiftX + 0.f , shiftY + (42.f * i));
+		}
+	}
+
+	void LoadLeaderboard(UI& uI, const Game& game)
+	{
+		for (int i = 0; i < LEADERBOARD_DISPLAY_SIZE; i++)
+		{
+			Vector2D relativePosition = GetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT);
+			Vector2D relativeOrigin = GetTextRelativeOrigin(uI.leaderboardItems[i]);
+
+			std::string textString = game.leaderboard[i].name + ".";
+			do
+			{
+				uI.leaderboardItems[i].setString(textString + std::to_string(game.leaderboard[i].score));
+				textString = textString + ".";
+
+			} while (uI.leaderboardItems[i].getLocalBounds().width < LEADERBOARD_WIDTH);
+
+			SetTextRelativeOrigin(uI.leaderboardItems[i], relativeOrigin.x, relativeOrigin.y);
+			SetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT, relativePosition.x, relativePosition.y);
+		}
 	}
 }
 

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -37,12 +37,12 @@ namespace ApplesGame
 		}
 
 		// Init Score
-		uI.score.setString("score");
-		uI.score.setFont(game.font);
-		uI.score.setCharacterSize(20);
-		uI.score.setFillColor(sf::Color::Yellow);
-		SetTextRelativeOrigin(uI.score, 0.f, 0.f);
-		SetTextScreenRelativePosition(uI.score, SCREEN_WIDTH, SCREEN_HEIGHT, 0.01f, 0.01f);
+		uI.playerScore.setString("score");
+		uI.playerScore.setFont(game.font);
+		uI.playerScore.setCharacterSize(20);
+		uI.playerScore.setFillColor(sf::Color::Yellow);
+		SetTextRelativeOrigin(uI.playerScore, 0.f, 0.f);
+		SetTextScreenRelativePosition(uI.playerScore, SCREEN_WIDTH, SCREEN_HEIGHT, 0.01f, 0.01f);
 
 		//Init tint
 		uI.tint.setFillColor(sf::Color(0, 0, 0, 180));
@@ -51,12 +51,12 @@ namespace ApplesGame
 
 	void UpdateHUD(UI& uI, const Game& game)
 	{
-		UpdateTextAndPosition(uI.score, "Score: " + std::to_string(game.score));
+		UpdateTextAndPosition(uI.playerScore, "Score: " + std::to_string(game.playerScore));
 	}
 
 	void DrawHUD(UI& uI, sf::RenderWindow& window)
 	{
-		window.draw(uI.score);
+		window.draw(uI.playerScore);
 	}
 
 	void UpdateMenu(UI& uI, const Game& game)
@@ -89,12 +89,12 @@ namespace ApplesGame
 		}
 		case MenuState::PauseMenu:
 		{
-			UpdateTextAndPosition(uI.note, "Current score: " + std::to_string(game.score));
+			UpdateTextAndPosition(uI.note, "Current score: " + std::to_string(game.playerScore));
 			break;
 		}
 		case MenuState::GameOverMenu:
 		{
-			UpdateTextAndPosition(uI.note, "Final score: " + std::to_string(game.score));
+			UpdateTextAndPosition(uI.note, "Final score: " + std::to_string(game.playerScore));
 			break;
 		}
 		}

--- a/ApplesGame/UI.h
+++ b/ApplesGame/UI.h
@@ -17,6 +17,10 @@ namespace ApplesGame
 		MenuState menuState{};
 		MenuItem menuItems[NUM_MENU_ITEMS];
 		sf::RectangleShape tint;
+
+		// Leaderboard
+		bool showLeaderboard;
+		sf::Text leaderboardItems[LEADERBOARD_DISPLAY_SIZE];
 	};
 
 	struct Game;
@@ -42,4 +46,8 @@ namespace ApplesGame
 	void MoveMenuUp(UI& uI);
 
 	void MoveMenuDown(UI& uI);
+
+	void SetMenuItemsPosition(UI& uI, float shiftX, float shiftY);
+
+	void LoadLeaderboard(UI& uI, const Game& game);
 }

--- a/ApplesGame/UI.h
+++ b/ApplesGame/UI.h
@@ -8,7 +8,7 @@ namespace ApplesGame
 	struct UI
 	{
 		// HUD
-		sf::Text score;
+		sf::Text playerScore;
 
 		// Menus
 		sf::Text title;

--- a/ApplesGame/UI.h
+++ b/ApplesGame/UI.h
@@ -19,8 +19,10 @@ namespace ApplesGame
 		sf::RectangleShape tint;
 
 		// Leaderboard
-		bool showLeaderboard;
+		bool showLeaderboard = false;
 		sf::Text leaderboardItems[LEADERBOARD_DISPLAY_SIZE];
+		bool showNewRecordText = false;
+		sf::Text newRecord;
 	};
 
 	struct Game;
@@ -31,7 +33,7 @@ namespace ApplesGame
 
 	void DrawHUD(UI& uI, sf::RenderWindow& window);
 
-	void UpdateMenu(UI& uI, const Game& game);
+	void UpdateMenu(UI& uI, const Game& game, const float deltaTime);
 
 	void LoadNewMenu(UI& uI);
 
@@ -50,4 +52,6 @@ namespace ApplesGame
 	void SetMenuItemsPosition(UI& uI, float shiftX, float shiftY);
 
 	void LoadLeaderboard(UI& uI, const Game& game);
+
+	void UpdateBlinkText(sf::Text& text, const float blinkInterval, const float deltaTime);
 }


### PR DESCRIPTION
## What’s been done
- Added `Record` struct with `name` and `score` fields.
- Implemented a leaderboard as `std::vector<Record>`.
- When game starts, 5 fake entries are generated with random scores.
- When game ends, current player's score is added/updated.
- Manual insertion sort is used to keep the leaderboard sorted by score (descending).
- The leaderboard is displayed in the `GameOverMenu` and in a dedicated `LeaderboardMenu`.
- A blinking text appears when the player beats their personal best.

## How to test
1. Run the game, collect some apples (score).
2. Finish the game, the leaderboard appears with the player's result.
3. If the score improved, the blinking text should show up.
4. From the main menu, navigate to LeaderboardMenu, the same leaderboard should be displayed.

## Related issues
Closes #12, #13, #14, #15