### PR TITLE
refactor: implement leaderboard using unordered_map instead of vector

### DIFF
--- a/ApplesGame/Game.cpp
+++ b/ApplesGame/Game.cpp
@@ -43,7 +43,6 @@ namespace ApplesGame
 			PlaySound(game, game.deathSound);
 			SetMenuState(game.uI, MenuState::GameOverMenu);
 			UpdatePlayerScore(game);
-			SortLeaderboard(game.leaderboard);
 			LoadLeaderboard(game.uI, game);
 			break;
 		}
@@ -169,12 +168,11 @@ namespace ApplesGame
 
 		// Init leaderboard
 		game.leaderboard.clear();
-		game.leaderboard.push_back({ "Alice", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Bob", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Carol", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "Dave", GetRandomInt(1000,5000) });
-		game.leaderboard.push_back({ "John", GetRandomInt(1000,5000) });
-		SortLeaderboard(game.leaderboard);
+		game.leaderboard["Alice"] = GetRandomInt(1000, 5000);
+		game.leaderboard["Bob"] = GetRandomInt(1000, 5000);
+		game.leaderboard["Carol"] = GetRandomInt(1000, 5000);
+		game.leaderboard["Dave"] = GetRandomInt(1000, 5000);
+		game.leaderboard["John"] = GetRandomInt(1000, 5000);
 
 		game.apples = nullptr;
 		game.stones = nullptr;
@@ -413,22 +411,18 @@ namespace ApplesGame
 
 	void UpdatePlayerScore(Game& game)
 	{
-		bool isPlayerFound = false;
-		for (Record& entry : game.leaderboard)
+		auto entry = game.leaderboard.find(PLAYER_NAME);
+		if (entry != game.leaderboard.end())
 		{
-			if (entry.name == PLAYER_NAME)
+			if (game.playerScore > entry->second)
 			{
-				isPlayerFound = true;
-				if (game.playerScore > entry.score)
-				{
-					entry.score = game.playerScore;
-					game.uI.showNewRecordText = true;
-				}
-				break;
+				entry->second = game.playerScore;
+				game.uI.showNewRecordText = true;
 			}
 		}
-		if (!isPlayerFound) {
-			game.leaderboard.push_back({ PLAYER_NAME, game.playerScore });
+		else
+		{
+			game.leaderboard[PLAYER_NAME] = game.playerScore;
 			game.uI.showNewRecordText = true;
 		}
 	}

--- a/ApplesGame/Game.h
+++ b/ApplesGame/Game.h
@@ -8,6 +8,7 @@
 #include "GameMode.h"
 #include <SFML/Graphics.hpp>
 #include <SFML/Audio.hpp>
+#include <unordered_map>
 
 namespace ApplesGame
 {
@@ -26,7 +27,7 @@ namespace ApplesGame
 		GameState gameState{};
 		uint32_t gameMode = 0;
 		int playerScore = 0;
-		std::vector<Record> leaderboard;
+		std::unordered_map<std::string, int> leaderboard;
 
 		//Resources
 		sf::Texture playerTexture;

--- a/ApplesGame/GameMode.cpp
+++ b/ApplesGame/GameMode.cpp
@@ -174,18 +174,5 @@ namespace ApplesGame
 		}
 		return true;
 	}
-
-	void SortLeaderboard(std::vector<Record>& leaderboard) 
-	{
-		for (unsigned int i = 1; i < leaderboard.size(); ++i) 
-		{
-			unsigned int j = i;
-			while (j > 0 && leaderboard[j - 1].score < leaderboard[j].score) 
-			{
-				std::swap(leaderboard[j - 1], leaderboard[j]);
-				--j;
-			}
-		}
-	}
 }
 

--- a/ApplesGame/GameMode.h
+++ b/ApplesGame/GameMode.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Math.h"
-#include <vector>
 
 namespace ApplesGame
 {
@@ -10,12 +9,6 @@ namespace ApplesGame
 		uint32_t mask;
 		uint8_t max_value;
 		uint8_t min_value;
-	};
-
-	struct Record
-	{
-		std::string name;
-		int score;
 	};
 
 	extern const GameModeNum NumberOfApples;
@@ -50,6 +43,4 @@ namespace ApplesGame
 	float GetScoreMultiplier(uint32_t gameMode);
 
 	bool isGameModeConsistent(uint32_t gameMode);
-
-	void SortLeaderboard(std::vector<Record>& leaderboard);
 }

--- a/ApplesGame/Math.cpp
+++ b/ApplesGame/Math.cpp
@@ -104,4 +104,17 @@ namespace ApplesGame
 		}
 		return "No";
 	}
+
+	void SortLeaderboardDesc(std::vector<std::pair<std::string, int>>& leaderboard)
+	{
+		for (unsigned int i = 1; i < leaderboard.size(); ++i)
+		{
+			unsigned int j = i;
+			while (j > 0 && leaderboard[j - 1].second < leaderboard[j].second)
+			{
+				std::swap(leaderboard[j - 1], leaderboard[j]);
+				--j;
+			}
+		}
+	}
 }

--- a/ApplesGame/Math.h
+++ b/ApplesGame/Math.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <vector>
 
 namespace sf
 {
@@ -50,4 +51,6 @@ namespace ApplesGame
 	bool rollChance(float percent);
 
 	std::string BoolToString(const bool& flag);
+
+	void SortLeaderboardDesc(std::vector<std::pair<std::string, int>>& leaderboard);
 }

--- a/ApplesGame/UI.cpp
+++ b/ApplesGame/UI.cpp
@@ -266,10 +266,13 @@ namespace ApplesGame
 
 	void LoadLeaderboard(UI& uI, const Game& game)
 	{
-		int displayCount = LEADERBOARD_DISPLAY_SIZE;
-		if (game.leaderboard.size() < LEADERBOARD_DISPLAY_SIZE)
+		std::vector<std::pair<std::string, int>> leaderboard(game.leaderboard.begin(), game.leaderboard.end());
+		SortLeaderboardDesc(leaderboard);
+
+		size_t displayCount = LEADERBOARD_DISPLAY_SIZE;
+		if (leaderboard.size() < LEADERBOARD_DISPLAY_SIZE)
 		{
-			displayCount = game.leaderboard.size();
+			displayCount = leaderboard.size();
 		}
 
 		for (int i = 0; i < displayCount; i++)
@@ -277,10 +280,10 @@ namespace ApplesGame
 			Vector2D relativePosition = GetTextScreenRelativePosition(uI.leaderboardItems[i], SCREEN_WIDTH, SCREEN_HEIGHT);
 			Vector2D relativeOrigin = GetTextRelativeOrigin(uI.leaderboardItems[i]);
 
-			std::string textString = game.leaderboard[i].name + ".";
+			std::string textString = leaderboard[i].first + ".";
 			do
 			{
-				uI.leaderboardItems[i].setString(textString + std::to_string(game.leaderboard[i].score));
+				uI.leaderboardItems[i].setString(textString + std::to_string(leaderboard[i].second));
 				textString = textString + ".";
 
 			} while (uI.leaderboardItems[i].getLocalBounds().width < LEADERBOARD_WIDTH);


### PR DESCRIPTION
## What’s been done
- Leaderboard now uses `std::unordered_map<std::string, int>`.
- `Record` struct removed.
- For display, data is copied to a vector of pairs, sorted manually (insertion sort) by score descending.

## How to test
- Run game, play, finish. Leaderboard should appear and behave identically to the vector version.

## Related issues
Closes #16